### PR TITLE
Zonas de derrape ahora terminan en máximos/mínimos

### DIFF
--- a/avanceGraficoPista.m
+++ b/avanceGraficoPista.m
@@ -98,8 +98,8 @@ disp("(" + num2str(X1) + "," + num2str(Y1)+ ")");
 disp("(" + num2str(X2) + "," + num2str(Y2)+ ")");
 fprintf("\n");
 disp("Zonas de derrape (en intervalos):")
-fprintf("%f <= x <= %f\n", puntosRadio50(1), puntosRadio50(2));
-fprintf("%f <= x <= %f\n", puntosRadio50(3), puntosRadio50(4));
+fprintf("%f <= x <= %f\n", puntosRadio50(1), puntosCriticos(1));
+fprintf("%f <= x <= %f\n", puntosRadio50(3), puntosCriticos(2));
 
 %% GRAFICACION DE LA CURVA
 

--- a/avanceGraficoPista.m
+++ b/avanceGraficoPista.m
@@ -72,11 +72,11 @@ while(ecuationFound==false)
         disp("No se hallaron las coordenadas");
         ecuationFound = false;
     end
-    
+end
     % Se encuentran los puntos (las coordenadas en X de estos puntos, para
     % ser exactos) donde el radio de curvatura es igual a 50
-end
     puntosRadio50 = ZonasDeDerrape.xRadio50(eqn);
+    
 %% IMPRESIÓN DE DATOS IMPORTANTES
 
 fprintf("\n");
@@ -177,22 +177,22 @@ fclose(fileID);
 % Se grafican las zonas de derrape solo si están dentro de los límites de
 % la curva (si una parte está dentro de los límites, se grafica esa parte)
 if puntosRadio50(1) < X0
-    if puntosRadio50(2) > X0
-        fplot(eqn, [X0, puntosRadio50(2)], "Color", "red", ...
+    if puntosCriticos(1) > X0
+        fplot(eqn, [X0, puntosCriticos(1)], "Color", "red", ...
             "DisplayName", "Zona de derrape");
     end
 else
-    fplot(eqn, [puntosRadio50(1) puntosRadio50(2)], "Color", "red", ...
+    fplot(eqn, [puntosRadio50(1) puntosCriticos(1)], "Color", "red", ...
         "DisplayName", "Zona de derrape");
 end
 
-if puntosRadio50(4) > XF
+if puntosCriticos(2) > XF
     if puntosRadio50(3) < XF
         fplot(eqn, [puntosRadio50(3), XF], "Color", "red", ...
             "DisplayName", "Zona de derrape");
     end
 else
-    fplot(eqn, [puntosRadio50(3) puntosRadio50(4)], "Color", "red", ...
+    fplot(eqn, [puntosRadio50(3) puntosCriticos(2)], "Color", "red", ...
         "DisplayName", "Zona de derrape");
 end
 


### PR DESCRIPTION
En el PowerPoint del Profe se ve que las zonas de derrape deben comenzar en el punto donde el radio de curvatura es igual a 50, y terminar en el punto máximo o mínimo de la función. Antes de este pull request terminaban en el otro punto donde el radio de curvatura era igual a 50, haciéndolas (aprox.) el doble de largas de lo que debían ser.
![patch](https://user-images.githubusercontent.com/72269728/99707600-ad75a380-2a6a-11eb-9273-ed34b75a3f25.png)

También cambié de lugar un comentario que estaba donde no era.
